### PR TITLE
Update versions to work with clap-verbosity-flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ authors = ["Yoshua Wuyts <yoshuawuyts@gmail.com>"]
 readme = "README.md"
 
 [dependencies]
-structopt = "0.2.10"
+structopt = "0.3"
 env_logger = "0.5.12"
 failure = "0.1.2"
 log = "0.4.3"
 pretty_env_logger = "0.2.4"
 
 [dev-dependencies]
-clap-verbosity-flag = "0.2.0"
+clap-verbosity-flag = "0.3.0"


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->

🐛 This is a bug fix

<!-- Provide a general summary of the changes in the title above -->

clap-verbosity-flag depends on structopt 0.3 (https://crates.io/crates/clap-verbosity-flag), while this package currently depends on structopt 0.2.10.

When using clap-verbosity-flag with clap-log-flag, they bring in different versions of StructOpt, which are incompatible.

I see this error in a local project when using `structopt = "0.3.17"`, `clap-verbosity-flag = "0.3.1"`, and `clap-log-flag = "0.2.1"`:

```
help: trait impl with same name found
   |
19 | #[derive(StructOpt, Debug)]
   |          ^^^^^^^^^
   = note: perhaps two different versions of crate `structopt` are being used?
   = note: required by `structopt::StructOpt::from_clap`
```

To fix this, depend on the same version of structopt as clap-verbosity-flag, and use a recent version of clap-verbosity-flag in dev-dependencies (so that tests check if everything's working).

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass

## Context
<!-- Is this related to any GitHub issue(s)? -->

## Semver Changes
<!-- Which semantic version change would you recommend? -->

Perhaps bump the minor version?